### PR TITLE
refactor node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ dependencies = [
  "jemallocator",
  "kv",
  "log",
+ "mio",
  "mmap",
  "reqwest",
  "rustreexo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ clap = { version = "4.5.20", features = ["derive"] }
 time = "0.3.36"
 ahash = "0.8.11"
 ctrlc = "3.4.5"
+mio = { version = "1.0.2", features = ["net", "os-poll"] }
 
 [features]
 default = ["bitcoin", "node", "api"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,17 @@ impl Network {
     }
 }
 
+impl From<Network> for bitcoin::Network {
+    fn from(network: Network) -> Self {
+        match network {
+            Network::Mainnet => bitcoin::Network::Bitcoin,
+            Network::Testnet3 => bitcoin::Network::Testnet,
+            Network::Signet => bitcoin::Network::Signet,
+            Network::Regtest => bitcoin::Network::Regtest,
+        }
+    }
+}
+
 #[derive(Debug, Parser)]
 pub struct CliArgs {
     /// If you want to run the bridge from a specific height, you can specify it here.

--- a/src/leaf_cache.rs
+++ b/src/leaf_cache.rs
@@ -112,7 +112,6 @@ impl DiskLeafStorage {
             // Don't uncache things that are too recent
             if *height < 100 {
                 new_map.insert(*outpoint, (*height, leaf_data.clone()));
-                continue;
             }
 
             let serialized = Self::serialize_leaf_data(leaf_data);

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,15 +142,3 @@ fn get_chain_provider() -> Result<Box<dyn Blockchain>> {
         Err(e) => Err(anyhow::anyhow!("Couldn't connect to bitcoin core: {e}")),
     }
 }
-
-#[cfg(not(feature = "shinigami"))]
-macro_rules! try_and_log_error {
-    ($op:expr) => {
-        if let Err(e) = $op {
-            error!("Error: {}", e);
-        }
-    };
-}
-
-#[cfg(not(feature = "shinigami"))]
-pub(crate) use try_and_log_error;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,19 +1,55 @@
 //SPDX-License-Identifier: MIT
 
+/// A simple and efficient implementation of Bitcoin P2P network
+///
+/// This bridge software gives you the option to serve proofs and blocks over the
+/// p2p port, just like any other node. The way it works is simple and meant to use
+/// as little deps as possible. We explicitly don't use async/await on this.
+///
+/// ## Architecture
+///
+/// This implementation uses async IO, but without the overhead of proper async/await.
+/// It is broken down in three modules: [Reactor], [Worker] and [Peer].
+///   - [Reactor]: We only have one of those, it will run in a loop, polling different sockets for events. If
+///                the socket gets ready for read/write, the reactor should send the socket
+///                and ID to one of our workers. The worker selection is random and assumes
+///                that they will take about the same time to handle each socket. In the future
+///                we may need to add a proper work distribution mechanism.
+///
+///   - [Worker]: We have a couple of workers, and each worker has one OS thread. When a socket is
+///               ready, one [Worker] will receive it using a channel. The actual [Peer] state is
+///               kept inside our workers, inside a shared vector. So, after receiver a notification,
+///               we pick the corresponding [Peer] and call `handle_request` to read from the socket
+///               and handle the request. `handle_request` don't write to the socket, only to a
+///               buffer. If needed, the worker will also write back that data.
+///
+///   - [Peer]: Holds all the context related to a [Peer] and handles requests. Since we may not
+///             read a hole [NetworkMessage] at once (or read more than one), we buffer everything
+///             in a read buffer. We also have a write buffer, and this is to both avoid too many
+///             syscalls, but also to avoid calling write too often, which should cause the socket
+///             to err on `WouldBlock`. If we don't succeed in sending all the buffer, the [Worker]
+///             will schedule us for write events (we won't read before finishing the write).
+use std::cell::UnsafeCell;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::Read;
 use std::io::Write;
-use std::net::TcpListener;
-use std::net::TcpStream;
+use std::net::SocketAddr;
+use std::rc::Rc;
 use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
 use std::sync::Arc;
+use std::sync::PoisonError;
 use std::sync::RwLock;
+use std::time::Duration;
+use std::time::Instant;
 
 use bitcoin::consensus::deserialize;
 use bitcoin::consensus::serialize;
 use bitcoin::consensus::Decodable;
-use bitcoin::consensus::Encodable;
 use bitcoin::hashes::Hash;
+use bitcoin::key::rand::random;
 use bitcoin::p2p::message::NetworkMessage;
 use bitcoin::p2p::message::RawNetworkMessage;
 use bitcoin::p2p::message_blockdata::Inventory;
@@ -22,23 +58,52 @@ use bitcoin::p2p::message_network::VersionMessage;
 use bitcoin::p2p::Magic;
 use bitcoin::p2p::ServiceFlags;
 use bitcoin::BlockHash;
+use log::debug;
 use log::error;
 use log::info;
+use mio::net::TcpListener;
+use mio::net::TcpStream;
 use sha2::Digest;
 use sha2::Sha256;
 
 use crate::block_index::BlocksIndex;
 use crate::blockfile::BlockFile;
 use crate::chainview::ChainView;
-use crate::try_and_log_error;
 
 const FILTER_TYPE_UTREEXO: u8 = 1;
+const WORKES_PER_CLUSTER: usize = 4;
 
+#[derive(Debug)]
+/// A minimal version of the message header
+///
+/// We need this because `rust-bitcoin` won't let us read only the reader, only the full message.
+/// But we may need this to figure out whether we have all the data, or should just wait for a
+/// while.
 pub struct P2PMessageHeader {
+    /// Magic data that's always in the beginning of a message
+    ///
+    /// This constant is defined per-network, and if it doesn't match what we expected, we'll
+    /// disconnect with that peer
     _magic: Magic,
+    /// A command string telling what this message should be (e.g.: block, inv, tx)
     _command: [u8; 12],
+    /// How long this message is
     length: u32,
+    /// The payload's checksum
     _checksum: u32,
+}
+
+#[derive(Clone)]
+/// Data required by our peers to handle requests
+pub struct WorkerContext {
+    /// The actual blocks and proofs
+    pub proof_backend: Arc<RwLock<BlockFile>>,
+    /// An index on [BlockFile] so we can get specific blocks
+    pub proof_index: Arc<BlocksIndex>,
+    /// Our chain metadata. Things like our height, and  an index height -> hash
+    pub chainview: Arc<ChainView>,
+    /// The magic bits for the network we are on
+    pub magic: Magic,
 }
 
 impl Decodable for P2PMessageHeader {
@@ -57,81 +122,595 @@ impl Decodable for P2PMessageHeader {
         })
     }
 }
-pub struct Node {
-    listener: TcpListener,
-    proof_backend: Arc<RwLock<BlockFile>>,
-    proof_index: Arc<BlocksIndex>,
-    chainview: Arc<ChainView>,
-    sockets: Arc<RwLock<Vec<TcpStream>>>,
-}
 
+/// A struct that will set everything up and running. It doesn't have any state nor runs on any
+/// thread, but after calling `run` you should have the [Reactor] and [Worker]s running
+pub struct Node;
+
+/// Local context for each peer
+///
+/// This will perform all the processing and IO related to a given peer, it can will be owned by
+/// our workers and used every time the reactor tell us there's something available
 pub struct Peer {
+    /// Data that we've read, but didn't process
+    read_buffer: Vec<u8>,
+    /// Data that we need to write into the socket
+    write_buffer: Vec<u8>,
+    /// Where we can get blocks to send to peers
     proof_backend: Arc<RwLock<BlockFile>>,
-    reader: TcpStream,
-    writer: TcpStream,
+    /// Index to learn where things are inside the [BlockFile]
     proof_index: Arc<BlocksIndex>,
+    /// General info about our chain
     chainview: Arc<ChainView>,
+    /// Magic bits used in every network message
+    magic: Magic,
 }
 
 #[derive(Debug)]
-enum ReadError {
-    IoError(std::io::Error),
-    DecodeError(bitcoin::consensus::encode::Error),
+/// Errors returned by the [Peer] when processing requests
+enum PeerError {
+    /// Io Error
+    Io(std::io::Error),
+    /// Can't decode the message
+    Decode(bitcoin::consensus::encode::Error),
+    /// Some lock is poisoned (a thread died while holding it)
+    Poison,
+    /// The provided magic value is invalid
+    InvalidMagic,
+    /// The message we got is too big
+    MessageTooLarge,
 }
 
-impl Display for ReadError {
+impl Display for PeerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ReadError::IoError(e) => write!(f, "IO error: {}", e),
-            ReadError::DecodeError(e) => write!(f, "Decode error: {}", e),
+            PeerError::Io(e) => write!(f, "IO error: {}", e),
+            PeerError::Decode(e) => write!(f, "Decode error: {}", e),
+            PeerError::Poison => write!(f, "Lock is poisoned"),
+            PeerError::InvalidMagic => write!(f, "Invalid magic"),
+            PeerError::MessageTooLarge => write!(f, "Message too large"),
         }
     }
 }
 
-impl From<std::io::Error> for ReadError {
+impl From<std::io::Error> for PeerError {
     fn from(e: std::io::Error) -> Self {
-        Self::IoError(e)
+        PeerError::Io(e)
     }
 }
 
-impl From<bitcoin::consensus::encode::Error> for ReadError {
+impl From<bitcoin::consensus::encode::Error> for PeerError {
     fn from(e: bitcoin::consensus::encode::Error) -> Self {
-        Self::DecodeError(e)
+        PeerError::Decode(e)
+    }
+}
+
+impl<T> From<PoisonError<T>> for PeerError {
+    fn from(_: PoisonError<T>) -> Self {
+        PeerError::Poison
+    }
+}
+
+impl Node {
+    /// Spawn a reactor and some workers to handle requests.
+    ///
+    /// If we can't set things up, this function will panic
+    pub fn run(
+        address: SocketAddr,
+        worker_context: WorkerContext,
+        block_notifier: Receiver<BlockHash>,
+    ) {
+        let listener = TcpListener::bind(address).expect("Failed to bind to address");
+        let (register, register_rx) = std::sync::mpsc::channel();
+        let reactor = Reactor {
+            block_notifier,
+            listener,
+            registered: HashMap::new(),
+            register: register_rx,
+            worker_pool: Self::create_workers(&worker_context, register),
+            magic: worker_context.magic,
+            pings: BTreeMap::new(),
+            timeouts: BTreeMap::new(),
+        };
+
+        std::thread::Builder::new()
+            .name("bridge - reactor thread".to_string())
+            .spawn(move || reactor.run())
+            .expect("Failed to spawn reactor");
+    }
+
+    /// spawns our workers
+    fn create_workers(
+        worker_context: &WorkerContext,
+        scheduler: Sender<(usize, TcpStream, Intent)>,
+    ) -> [Sender<Message>; WORKES_PER_CLUSTER] {
+        let mut workers = Vec::new();
+        let peers = Rc::new(UnsafeCell::new(HashMap::new()));
+        for i in 0..WORKES_PER_CLUSTER {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let worker = Worker::new(
+                i,
+                peers.clone(),
+                worker_context.proof_backend.clone(),
+                worker_context.proof_index.clone(),
+                worker_context.chainview.clone(),
+                worker_context.magic,
+                rx,
+                scheduler.clone(),
+            );
+
+            std::thread::Builder::new()
+                .name(format!("bridge - worker {}", i))
+                .spawn(move || worker.run())
+                .expect("Failed to spawn worker");
+
+            workers.push(tx);
+        }
+
+        workers.try_into().expect("Failed to create workers")
+    }
+}
+
+#[derive(Debug)]
+/// Messages sent from [Reactor] to [Worker]
+pub enum Message {
+    /// The server got a new connection
+    ///
+    /// Once a worker gets this, it'll construct a [Peer] struct and schedule it for the next
+    /// message
+    NewConnection(TcpStream),
+    /// There's something to read in the socket
+    ReadReady((TcpStream, usize)),
+    /// We can write to the socket
+    WriteReady((TcpStream, usize)),
+    /// Some peer disconnected (either them or us killed the socket)
+    Disconnect(usize),
+}
+
+#[derive(Debug)]
+/// What are we waiting for
+enum Intent {
+    Read,
+    Write,
+}
+
+/// A struct that will run and wait for work to do. Once it gets a new work from [Reactor], it will
+/// call the relevant functions and use its cpu share to make progress
+struct Worker {
+    /// A unique per-worker identifier
+    id: usize,
+    /// The channel used by [Reactor] to notify us about new things to do
+    job_receiver: Receiver<Message>,
+    /// A shared memory region that holds all our [Peer]s
+    ///
+    /// Since we know that never two workers will try to operate on the same [Peer], and also that
+    /// all changes to the actual [HashMap] will always be made by worker `0` (see the reactor
+    /// bellow). We don't need to worry about synchronization here. Moreover, we'll never drop
+    /// this, as our workers lives through the entire lifetime of our program, we don't need an
+    /// [Arc].
+    peers: Rc<UnsafeCell<HashMap<usize, Peer>>>,
+    /// A channel to ask the [Reactor] to notify us about new events
+    scheduler: Sender<(usize, TcpStream, Intent)>,
+
+    /// We use those to build [Peer]
+    proof_backend: Arc<RwLock<BlockFile>>,
+    proof_index: Arc<BlocksIndex>,
+    chainview: Arc<ChainView>,
+    magic: Magic,
+}
+
+unsafe impl Sync for Worker {}
+unsafe impl Send for Worker {}
+
+impl Worker {
+    /// Creates a new worker
+    ///
+    /// This function doesn't spawn any thread, the caller is responsible for running [Worker::run]
+    /// inside a thread
+    fn new(
+        id: usize,
+        peers: Rc<UnsafeCell<HashMap<usize, Peer>>>,
+        proof_backend: Arc<RwLock<BlockFile>>,
+        proof_index: Arc<BlocksIndex>,
+        chainview: Arc<ChainView>,
+        magic: Magic,
+        job_receiver: Receiver<Message>,
+        scheduler: Sender<(usize, TcpStream, Intent)>,
+    ) -> Self {
+        Self {
+            peers,
+            scheduler,
+            id,
+            proof_backend,
+            proof_index,
+            chainview,
+            magic,
+            job_receiver,
+        }
+    }
+
+    /// Takes ownership of the worker and runs until this thread dies
+    fn run(self) {
+        debug!("Worker {} started", self.id);
+        loop {
+            let job = self
+                .job_receiver
+                .recv()
+                .expect("job_receiver channel is broken");
+
+            match job {
+                Message::NewConnection(socket) => {
+                    let peer = Peer::new(
+                        "unknown".to_string(),
+                        "unknown".to_string(),
+                        self.proof_backend.clone(),
+                        self.proof_index.clone(),
+                        self.chainview.clone(),
+                        self.magic,
+                    );
+
+                    let id: usize = random();
+                    let peers = unsafe { &mut *self.peers.get() };
+
+                    peers.insert(id, peer);
+                    self.scheduler
+                        .send((id, socket, Intent::Read))
+                        .expect("reactor died");
+                }
+
+                Message::ReadReady((mut stream, id)) => {
+                    debug!("worker: got read event for peer {id}");
+
+                    let peers = unsafe { &mut *self.peers.get() };
+                    let Some(peer) = peers.get_mut(&id) else {
+                        log::error!("can't find peer: {id}");
+                        peers.remove(&id);
+                        continue;
+                    };
+
+                    if let Err(err) = peer.handle_request(&mut stream) {
+                        log::error!("Error handling request: {}", err);
+                        if let PeerError::Io(ref e) = err {
+                            if e.kind() == std::io::ErrorKind::WouldBlock {
+                                self.scheduler
+                                    .send((id, stream, Intent::Read))
+                                    .expect("reactor died");
+
+                                continue;
+                            }
+                        }
+
+                        peers.remove(&id);
+                        continue;
+                    }
+
+                    match peer.write_back(&mut stream) {
+                        Ok(true) => self
+                            .scheduler
+                            .send((id, stream, Intent::Read))
+                            .expect("reactor died"),
+
+                        Ok(false) => self
+                            .scheduler
+                            .send((id, stream, Intent::Write))
+                            .expect("reactor died"),
+
+                        Err(err) => {
+                            log::error!("Error handling request: {}", err);
+                            if let PeerError::Io(ref e) = err {
+                                if e.kind() == std::io::ErrorKind::WouldBlock {
+                                    self.scheduler
+                                        .send((id, stream, Intent::Write))
+                                        .expect("reactor died");
+                                    continue;
+                                }
+                            }
+
+                            peers.remove(&id);
+                            continue;
+                        }
+                    }
+                }
+
+                Message::WriteReady((mut stream, id)) => {
+                    debug!("worker: got event for peer {id}");
+
+                    let peers = unsafe { &mut *self.peers.get() };
+                    let Some(peer) = peers.get_mut(&id) else {
+                        log::error!("can't find peer: {id}");
+                        peers.remove(&id);
+                        continue;
+                    };
+
+                    match peer.write_back(&mut stream) {
+                        Ok(true) => self
+                            .scheduler
+                            .send((id, stream, Intent::Read))
+                            .expect("reactor died"),
+
+                        Ok(false) => self
+                            .scheduler
+                            .send((id, stream, Intent::Write))
+                            .expect("reactor died"),
+
+                        Err(err) => {
+                            log::error!("Error handling request: {}", err);
+                            if let PeerError::Io(ref e) = err {
+                                if e.kind() == std::io::ErrorKind::WouldBlock {
+                                    self.scheduler
+                                        .send((id, stream, Intent::Write))
+                                        .expect("reactor died");
+                                    continue;
+                                }
+                            }
+
+                            peers.remove(&id);
+                            continue;
+                        }
+                    }
+                }
+
+                Message::Disconnect(id) => {
+                    info!("worker: peer {id} disconnected");
+
+                    let peers = unsafe { &mut *self.peers.get() };
+                    peers.remove(&id);
+                }
+            }
+        }
+    }
+}
+
+/// Keep watching sockets for new events
+struct Reactor {
+    /// Our server's listener
+    ///
+    /// Used to accept new p2p connections
+    listener: TcpListener,
+    /// Channels to our workers
+    worker_pool: [Sender<Message>; WORKES_PER_CLUSTER],
+    /// A channel we use to receive things to watch
+    register: Receiver<(usize, TcpStream, Intent)>,
+    /// Sockets we are watching
+    registered: HashMap<usize, (TcpStream, Intent)>,
+    /// This channel will notify us about new blocks
+    block_notifier: Receiver<BlockHash>,
+    /// Magic value for this network
+    magic: Magic,
+    /// If a peer doesn't send us a message for too long, poke it to see if it's still alive
+    timeouts: BTreeMap<Instant, usize>,
+    /// pings we've sent
+    pings: BTreeMap<Instant, usize>,
+}
+
+impl Reactor {
+    fn run(mut self) {
+        let mut poll = mio::Poll::new().expect("can't create a mio Poller");
+        poll.registry()
+            .register(&mut self.listener, mio::Token(0), mio::Interest::READABLE)
+            .expect("Failed to register listener");
+
+        let mut events = mio::Events::with_capacity(1024);
+        loop {
+            let registry = poll.registry();
+            while let Ok(mut work) = self.register.try_recv() {
+                debug!("reactor: registering {} for {:?}", work.0, work.2);
+
+                self.timeouts
+                    .insert(Instant::now() + Duration::from_secs(10 * 60), work.0);
+
+                let intent = match work.2 {
+                    Intent::Read => mio::Interest::READABLE,
+                    Intent::Write => mio::Interest::WRITABLE,
+                };
+
+                match registry.register(&mut work.1, mio::Token(work.0), intent) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        log::error!("Failed to register socket: {}", e);
+                        continue;
+                    }
+                }
+
+                self.registered.insert(work.0, (work.1, work.2));
+            }
+
+            let next_timeout = self
+                .timeouts
+                .iter()
+                .next()
+                .map(|(t, _)| t.duration_since(Instant::now()));
+
+            if let Err(e) = poll.poll(
+                &mut events,
+                Some(next_timeout.unwrap_or(Duration::from_secs(1))),
+            ) {
+                log::error!("Failed to poll: {}", e);
+                continue;
+            }
+
+            self.block_notifier.try_iter().for_each(|block| {
+                let inv = RawNetworkMessage::new(
+                    self.magic,
+                    NetworkMessage::Inv(vec![Inventory::Block(block)]),
+                );
+
+                let msg = serialize(&inv);
+
+                self.registered.iter_mut().for_each(|(_, (socket, _))| {
+                    let _ = socket.write_all(&msg);
+                });
+            });
+
+            let registry = poll.registry();
+            for event in events.iter() {
+                match event.token() {
+                    mio::Token(0) => {
+                        debug!("reactor: our listener got a new event");
+
+                        let Ok((stream, address)) = self.listener.accept() else {
+                            log::error!("Failed to accept connection");
+                            continue;
+                        };
+
+                        info!("reactor: saw new connection from {address}");
+
+                        self.worker_pool[0]
+                            .send(Message::NewConnection(stream))
+                            .expect("Failed to send new connection to worker");
+                    }
+
+                    mio::Token(token) => {
+                        debug!("reactor: event for {token}");
+
+                        if event.is_read_closed() || event.is_write_closed() || event.is_error() {
+                            let (mut socket, _) = self
+                                .registered
+                                .remove(&token)
+                                .expect("BUG: socket is registered but not in registered map");
+
+                            if let Err(e) = registry.deregister(&mut socket) {
+                                error!("can't deregister socket {token} due to {e:?}");
+                                continue;
+                            }
+
+                            self.pings.retain(|_, id| id != &token);
+                            self.timeouts.retain(|_, id| id != &token);
+                            self.worker_pool[0]
+                                .send(Message::Disconnect(token))
+                                .expect("Failed to send disconnect to worker");
+                            continue;
+                        }
+
+                        let worker_id = random::<usize>() % self.worker_pool.len();
+                        let worker = self.worker_pool.get(worker_id).expect("broken worker");
+                        let (mut socket, intent) = self
+                            .registered
+                            .remove(&token)
+                            .expect("BUG: socket is registered but not in registered map");
+
+                        if let Err(e) = registry.deregister(&mut socket) {
+                            error!("can't deregister socket {token} due to {e:?}");
+                            continue;
+                        }
+
+                        self.pings.retain(|_, id| id != &token);
+                        self.timeouts.retain(|_, id| id != &token);
+
+                        debug!("reactor: sending job to worker {}", worker_id);
+                        match intent {
+                            Intent::Read => {
+                                worker
+                                    .send(Message::ReadReady((socket, token)))
+                                    .expect("Failed to send to worker");
+                            }
+                            Intent::Write => {
+                                worker
+                                    .send(Message::WriteReady((socket, token)))
+                                    .expect("Failed to send to worker");
+                            }
+                        }
+                    }
+                }
+            }
+
+            let now = Instant::now();
+            let new_timeout = self.timeouts.split_off(&now);
+
+            for (_, id) in self.timeouts {
+                debug!("reactor: sending ping to {id}");
+                let nonce = random();
+                let ping = RawNetworkMessage::new(self.magic, NetworkMessage::Ping(nonce));
+
+                let msg = serialize(&ping);
+                let (socket, _) = self
+                    .registered
+                    .get_mut(&id)
+                    .expect("BUG: socket is registered but not in registered map");
+
+                match socket.write_all(&msg) {
+                    Ok(_) => {
+                        self.pings.insert(now + Duration::from_secs(30), id);
+                    }
+                    Err(e) => {
+                        log::error!("Failed to send ping: {}", e);
+                        self.registered.remove(&id);
+                        self.worker_pool[0]
+                            .send(Message::Disconnect(id))
+                            .expect("Failed to send disconnect to worker");
+                        continue;
+                    }
+                }
+            }
+
+            self.timeouts = new_timeout;
+            for (time, id) in self.pings.iter() {
+                // request timed out, assume peer died
+                if *time < now {
+                    debug!("reactor: peer {id} timed out ping");
+
+                    self.worker_pool[0]
+                        .send(Message::Disconnect(*id))
+                        .expect("Failed to send disconnect to worker");
+                    self.registered.remove(id);
+                }
+            }
+        }
     }
 }
 
 impl Peer {
     pub fn new(
-        stream: TcpStream,
         _peer: String,
         _peer_id: String,
         proof_backend: Arc<RwLock<BlockFile>>,
         proof_index: Arc<BlocksIndex>,
         chainview: Arc<ChainView>,
+        magic: Magic,
     ) -> Self {
-        let reader = stream.try_clone().unwrap();
         Self {
             proof_backend,
             proof_index,
-            reader,
-            writer: stream,
             chainview,
+            magic,
+            write_buffer: Vec::new(),
+            read_buffer: Vec::new(),
         }
     }
 
-    fn send_message(&mut self, message: RawNetworkMessage) {
-        let mut msg = Vec::new();
-        message.consensus_encode(&mut msg).unwrap();
+    fn consume_message(&mut self) -> Result<Option<RawNetworkMessage>, PeerError> {
+        let mut reader = self.read_buffer.as_slice();
+        let header = P2PMessageHeader::consensus_decode(&mut reader)?;
+        if header.length > 32_000_000 {
+            return Err(PeerError::MessageTooLarge);
+        }
 
-        try_and_log_error!(self.writer.write_all(&msg));
+        if header._magic != self.magic {
+            return Err(PeerError::InvalidMagic);
+        }
+
+        if self.read_buffer.len() < (header.length + 24) as usize {
+            return Ok(None);
+        }
+
+        let data = self.read_buffer.drain(0..(24 + header.length as usize));
+        let message = RawNetworkMessage::consensus_decode(&mut data.as_slice())?;
+        Ok(Some(message))
     }
 
-    fn read_header(&mut self) -> Result<([u8; 24], P2PMessageHeader), ReadError> {
-        let mut raw_header: [u8; 24] = [0; 24];
-        self.reader.read_exact(&mut raw_header)?;
+    fn send_message(&mut self, message: NetworkMessage) -> Result<(), PeerError> {
+        let msg = RawNetworkMessage::new(self.magic, message);
+        self.write_buffer.extend(&serialize(&msg));
 
-        let mut reader = raw_header.as_slice();
-        Ok((raw_header, P2PMessageHeader::consensus_decode(&mut reader)?))
+        Ok(())
+    }
+
+    fn read_pending(&mut self, stream: &mut TcpStream) -> Result<usize, PeerError> {
+        let mut buffer = vec![0; 32_000_000];
+        let read = stream.read(&mut buffer)?;
+
+        self.read_buffer.extend(buffer.drain(0..read));
+        Ok(read)
     }
 
     fn sha256d_payload(&self, payload: &[u8]) -> [u8; 32] {
@@ -145,25 +724,42 @@ impl Peer {
         sha.finalize().into()
     }
 
-    fn handle_request(&mut self) -> Result<(), ReadError> {
-        let (raw_header, parsed_header) = self.read_header()?;
+    fn write_back(&mut self, stream: &mut TcpStream) -> Result<bool, PeerError> {
+        debug!("peer: writing back {} bytes", self.write_buffer.len());
 
-        if parsed_header.length > 32_000_000 {
-            return Ok(());
+        let writen = stream.write(&self.write_buffer)?;
+        self.write_buffer.drain(0..writen);
+        Ok(self.write_buffer.is_empty())
+    }
+
+    fn handle_request(&mut self, stream: &mut TcpStream) -> Result<(), PeerError> {
+        let read = self.read_pending(stream)?;
+        debug!("peer: read {read} bytes");
+
+        loop {
+            if self.read_buffer.len() < 24 {
+                break;
+            }
+
+            let Some(request) = self.consume_message()? else {
+                break;
+            };
+
+            self.handle_request_inner(request, stream)?;
         }
 
-        let mut raw_payload = vec![0; (parsed_header.length + 24) as usize];
-        raw_payload[..24].copy_from_slice(&raw_header);
-        self.reader.read_exact(&mut raw_payload[24..])?;
+        Ok(())
+    }
 
-        let mut reader = raw_payload.as_slice();
-        let request = RawNetworkMessage::consensus_decode(&mut reader)?;
-
+    fn handle_request_inner(
+        &mut self,
+        request: RawNetworkMessage,
+        stream: &mut TcpStream,
+    ) -> Result<(), PeerError> {
         match request.payload() {
             NetworkMessage::Ping(nonce) => {
-                let pong = RawNetworkMessage::new(*request.magic(), NetworkMessage::Pong(*nonce));
-
-                self.send_message(pong);
+                let pong = NetworkMessage::Pong(*nonce);
+                self.send_message(pong)?;
             }
 
             NetworkMessage::GetData(inv) => {
@@ -182,12 +778,11 @@ impl Peer {
                                         hash: *hash,
                                     }]);
 
-                                let res = RawNetworkMessage::new(*request.magic(), not_found);
-                                self.send_message(res);
+                                self.send_message(not_found)?;
                                 continue;
                             };
 
-                            let lock = self.proof_backend.read().unwrap();
+                            let lock = self.proof_backend.read()?;
                             let payload = lock.get_block_slice(block);
                             let checksum = &self.sha256d_payload(payload)[0..4];
 
@@ -198,30 +793,24 @@ impl Peer {
                                 .copy_from_slice(&(payload.len() as u32).to_le_bytes());
                             message_header[20..24].copy_from_slice(checksum);
 
-                            self.writer.write_all(&message_header)?;
-                            self.writer.write_all(payload)?;
+                            stream.write_all(&message_header)?;
+                            stream.write_all(payload)?;
                         }
                         Inventory::WitnessBlock(block_hash) => {
                             let Some(block) = self.proof_index.get_index(*block_hash) else {
-                                let res = RawNetworkMessage::new(
-                                    *request.magic(),
+                                let not_found =
                                     NetworkMessage::NotFound(vec![Inventory::WitnessBlock(
                                         *block_hash,
-                                    )]),
-                                );
-                                self.send_message(res);
+                                    )]);
+                                self.send_message(not_found)?;
                                 continue;
                             };
-                            let lock = self.proof_backend.read().unwrap();
+                            let lock = self.proof_backend.read().expect("lock failed");
                             match lock.get_block(block) {
                                 //TODO: Rust-Bitcoin asks for a block, but we have it serialized on disk already.
                                 //      We should be able to just send the block without deserializing it.
                                 Some(block) => {
-                                    let block = RawNetworkMessage::new(
-                                        *request.magic(),
-                                        NetworkMessage::Block(block.into()),
-                                    );
-
+                                    let block = NetworkMessage::Block(block.into());
                                     blocks.push(block);
                                 }
                                 None => {
@@ -230,7 +819,7 @@ impl Peer {
                                             *block_hash,
                                         )]);
 
-                                    let res = RawNetworkMessage::new(*request.magic(), not_foud);
+                                    let res = not_foud;
                                     blocks.push(res);
                                 }
                             }
@@ -240,17 +829,20 @@ impl Peer {
                     }
                 }
 
-                blocks
-                    .into_iter()
-                    .for_each(|block| self.send_message(block));
+                for block in blocks {
+                    self.send_message(block)?;
+                }
             }
 
             NetworkMessage::GetHeaders(locator) => {
                 let mut headers = vec![];
-                let block = *locator.locator_hashes.first().unwrap();
-                let height = self.chainview.get_height(block).unwrap().unwrap_or(0);
-                let height = height + 1;
+                let Some(block) = locator.locator_hashes.first() else {
+                    return Ok(());
+                };
 
+                let height = self.chainview.get_height(*block).unwrap().unwrap_or(0);
+
+                let height = height + 1;
                 for h in height..(height + 2_000) {
                     let Ok(Some(block_hash)) = self.chainview.get_block_hash(h) else {
                         break;
@@ -260,14 +852,12 @@ impl Peer {
                         break;
                     };
 
-                    let header = deserialize(&header_info).unwrap();
+                    let header = deserialize(&header_info)?;
                     headers.push(header);
                 }
 
-                let headers =
-                    RawNetworkMessage::new(*request.magic(), NetworkMessage::Headers(headers));
-
-                self.send_message(headers);
+                let headers = NetworkMessage::Headers(headers);
+                self.send_message(headers)?;
             }
 
             NetworkMessage::Version(version) => {
@@ -296,11 +886,11 @@ impl Peer {
                     relay: false,
                 });
 
-                let our_version = RawNetworkMessage::new(*request.magic(), version);
-                self.send_message(our_version);
+                let our_version = version;
+                self.send_message(our_version)?;
 
-                let verack = RawNetworkMessage::new(*request.magic(), NetworkMessage::Verack);
-                self.send_message(verack);
+                let verack = NetworkMessage::Verack;
+                self.send_message(verack)?;
             }
 
             NetworkMessage::GetCFilters(req) => {
@@ -316,8 +906,7 @@ impl Peer {
                         filter: acc,
                     });
 
-                    let cfilter = RawNetworkMessage::new(*request.magic(), cfilters);
-                    self.send_message(cfilter);
+                    self.send_message(cfilters)?;
                 }
 
                 // ignore unknown filter types
@@ -325,89 +914,7 @@ impl Peer {
 
             _ => {}
         }
+
         Ok(())
-    }
-
-    pub fn peer_loop(mut self) {
-        loop {
-            if self.handle_request().is_err() {
-                info!("Connection closed");
-                break;
-            }
-        }
-    }
-}
-
-impl Node {
-    pub fn new(
-        listener: TcpListener,
-        proof_backend: Arc<RwLock<BlockFile>>,
-        proof_index: Arc<BlocksIndex>,
-        view: Arc<ChainView>,
-        new_blocks: Receiver<BlockHash>,
-        magic: Magic,
-    ) -> Self {
-        let sockets = Arc::new(RwLock::new(vec![]));
-        let closure_sockets = sockets.clone();
-
-        std::thread::spawn(move || {
-            Self::notify_loop(new_blocks, closure_sockets, magic);
-        });
-
-        Self {
-            listener,
-            proof_backend,
-            proof_index,
-            chainview: view,
-            sockets,
-        }
-    }
-
-    pub fn notify_loop(
-        new_blocks: Receiver<BlockHash>,
-        sockets: Arc<RwLock<Vec<TcpStream>>>,
-        magic: Magic,
-    ) {
-        loop {
-            let Ok(block_hash) = new_blocks.recv() else {
-                continue;
-            };
-
-            info!("New block: {}", block_hash);
-            let mut sockets = sockets.write().unwrap();
-            sockets.retain(|mut socket| {
-                let inv = RawNetworkMessage::new(
-                    magic,
-                    NetworkMessage::Inv(vec![Inventory::Block(block_hash)]),
-                );
-
-                let message = serialize(&inv);
-                socket.write_all(&message).is_ok()
-            });
-        }
-    }
-
-    pub fn accept_connections(self) {
-        loop {
-            if let Ok((stream, addr)) = self.listener.accept() {
-                info!("New connection from {}", addr);
-                let proof_backend = self.proof_backend.clone();
-                let proof_index = self.proof_index.clone();
-                self.sockets
-                    .write()
-                    .unwrap()
-                    .push(stream.try_clone().unwrap());
-
-                let peer = Peer::new(
-                    stream,
-                    addr.to_string(),
-                    addr.to_string(),
-                    proof_backend,
-                    proof_index,
-                    self.chainview.clone(),
-                );
-                std::thread::spawn(move || peer.peer_loop());
-            }
-        }
     }
 }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -356,14 +356,12 @@ impl<LeafStorage: LeafCache, Storage: BlockStorage> Prover<LeafStorage, Storage>
                     .map_err(|_| anyhow::anyhow!("Error sending response"))?;
             }
 
-            if last_tip_update.elapsed().as_secs() > 10 {
-                if let Err(e) = self.check_tip(&mut last_tip_update) {
-                    error!("Error checking tip: {}", e);
-                    continue;
-                }
+            if let Err(e) = self.check_tip(&mut last_tip_update) {
+                error!("Error checking tip: {}", e);
+                continue;
             }
 
-            std::thread::sleep(std::time::Duration::from_micros(100));
+            std::thread::sleep(std::time::Duration::from_secs(10));
         }
         self.save_to_disk(None)
             .expect("could not save the acc to disk");


### PR DESCRIPTION
The current implementation of the p2p node is completely broken. It uses one OS thread per peer and has no rate-limiting. This implementation uses a very basic async IO with a reactor and worker threads to handle peers.