### PR TITLE
Use optimal poseidon hash impl for two elements

### DIFF
--- a/src/udata.rs
+++ b/src/udata.rs
@@ -393,6 +393,7 @@ pub mod shinigami_udata {
     use bitcoin::Txid;
     use rustreexo::accumulator::node_hash::AccumulatorHash;
     use serde::Serialize;
+    use starknet_crypto::poseidon_hash;
     use starknet_crypto::poseidon_hash_many;
     use starknet_crypto::Felt;
 
@@ -511,7 +512,7 @@ pub mod shinigami_udata {
         // **both** children are not empty.
         fn parent_hash(left: &Self, right: &Self) -> Self {
             if let (PoseidonHash::Hash(left), PoseidonHash::Hash(right)) = (left, right) {
-                return PoseidonHash::Hash(poseidon_hash_many(&[*left, *right]));
+                return PoseidonHash::Hash(poseidon_hash(left, right));
             }
 
             // This should never happen, since rustreexo won't call this method unless both children


### PR DESCRIPTION
Poseidon hash of two arguments is a special case and is handled differently:
https://docs.starknet.io/architecture-and-concepts/cryptography/hash-functions/#poseidon_hash

Related to https://github.com/keep-starknet-strange/raito/pull/312