### PR TITLE
fix: add dotenv crate to read .env file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "bitcoincore-rpc",
  "clap",
  "ctrlc",
+ "dotenv",
  "futures",
  "hex",
  "jemallocator",
@@ -941,6 +942,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ time = "0.3.36"
 ahash = "0.8.11"
 ctrlc = "3.4.5"
 mio = { version = "1.0.2", features = ["net", "os-poll"] }
+dotenv = "0.15.0"
 
 [features]
 default = ["bitcoin", "node", "api"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ use anyhow::Result;
 use bitcoincore_rpc::Auth;
 use bitcoincore_rpc::Client;
 use chaininterface::Blockchain;
+use dotenv::dotenv;
 use jemallocator::Jemalloc;
 use log::info;
 use simplelog::Config;
@@ -66,6 +67,8 @@ pub mod bitcoin_bridge;
 use crate::bitcoin_bridge::run_bridge;
 
 fn main() -> anyhow::Result<()> {
+    dotenv().ok();
+
     run_bridge()
 }
 


### PR DESCRIPTION
The `.env ` file was not actually being read, but rather just `unwrap_or_else`ing to default values (local backend with cookie auth).

This PR adds the `dotenv` crate and reads the `.env` file via `dotenv().ok()`.