### PR TITLE
api: new endpoint for retrieving leaves

### DIFF
--- a/src/udata.rs
+++ b/src/udata.rs
@@ -12,7 +12,7 @@ use bitcoin::VarInt;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LeafContext {
     #[allow(dead_code)]
     pub block_hash: BlockHash,


### PR DESCRIPTION
This commit adds a new endpoint that returns the leaf hash and data associated to it. To use it, just GET at `/leaf/<txid>:<vout>`