### PR TITLE
fix(env): rename `API_PORT` to `API_HOST`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,10 +1,11 @@
 DATA_DIR=
 P2P_PORT=
-API_PORT=
-# if using bitcoin core as backend
+# <ip>:<port>
+API_HOST=
+# If using Bitcoin Core backend
 BITCOIN_CORE_COOKIE_FILE=
 BITCOIN_CORE_RPC_URL=
 BITCOIN_CORE_RPC_USER=
 BITCOIN_CORE_RPC_PASSWORD=
-# if using esplora as backend
+# If using Esplora backend
 ESPLORA_API_URL=


### PR DESCRIPTION
The code uses `API_HOST`, not `API_PORT`.

https://github.com/Davidson-Souza/rpc-utreexo-bridge/tree/main/src/bitcoin_bridge.rs#L152